### PR TITLE
Add use case that builds the Directed Acyclic Graph out of the dependency pairs

### DIFF
--- a/cacheinvalidationindex/build.gradle.kts
+++ b/cacheinvalidationindex/build.gradle.kts
@@ -18,6 +18,7 @@ gradlePlugin {
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
+    implementation(libs.jgrapht.core)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)

--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/CacheInvalidationIndexPlugin.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/CacheInvalidationIndexPlugin.kt
@@ -1,5 +1,6 @@
 package com.ivanalvarado.cacheinvalidationindex
 
+import com.ivanalvarado.cacheinvalidationindex.domain.usecase.BuildDagFromDependencyPairsImpl
 import com.ivanalvarado.cacheinvalidationindex.domain.usecase.FindDependencyPairsImpl
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -12,11 +13,12 @@ class CacheInvalidationIndexPlugin : Plugin<Project> {
             "cacheInvalidationIndex",
             CacheInvalidationIndexExtension::class.java
         )
-        val findDependencyPairs = FindDependencyPairsImpl()
+
         val cacheInvalidationIndexTaskProvider = project.tasks.register(
             "cacheInvalidationIndex",
             CacheInvalidationIndexTask::class.java,
-            findDependencyPairs
+            FindDependencyPairsImpl(),
+            BuildDagFromDependencyPairsImpl()
         )
         cacheInvalidationIndexTaskProvider.configure { task ->
             task.configurationToAnalyze.set(extension.configurationToAnalyze)

--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/CacheInvalidationIndexTask.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/CacheInvalidationIndexTask.kt
@@ -1,5 +1,6 @@
 package com.ivanalvarado.cacheinvalidationindex
 
+import com.ivanalvarado.cacheinvalidationindex.domain.usecase.BuildDagFromDependencyPairs
 import com.ivanalvarado.cacheinvalidationindex.domain.usecase.FindDependencyPairs
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.SetProperty
@@ -8,7 +9,8 @@ import org.gradle.api.tasks.TaskAction
 import javax.inject.Inject
 
 abstract class CacheInvalidationIndexTask @Inject constructor(
-    private val findDependencyPairs: FindDependencyPairs
+    private val findDependencyPairs: FindDependencyPairs,
+    private val buildDagFromDependencyPairs: BuildDagFromDependencyPairs
 ) : DefaultTask() {
 
     @get:Input
@@ -20,5 +22,7 @@ abstract class CacheInvalidationIndexTask @Inject constructor(
         val configurationsToAnalyze = configurationToAnalyze.get()
         val sampleList = findDependencyPairs(rootProject, configurationsToAnalyze)
         println("Dependency Pairs: $sampleList")
+        val dag = buildDagFromDependencyPairs(sampleList)
+        println("DAG: $dag")
     }
 }

--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/BuildDagFromDependencyPairs.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/BuildDagFromDependencyPairs.kt
@@ -1,0 +1,8 @@
+package com.ivanalvarado.cacheinvalidationindex.domain.usecase
+
+import org.gradle.api.Project
+import org.jgrapht.graph.DirectedAcyclicGraph
+
+interface BuildDagFromDependencyPairs {
+    operator fun invoke(dependencyPairs: List<Triple<Project, Project, String>>): DirectedAcyclicGraph<String, String>
+}

--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/BuildDagFromDependencyPairsImpl.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/BuildDagFromDependencyPairsImpl.kt
@@ -1,0 +1,21 @@
+package com.ivanalvarado.cacheinvalidationindex.domain.usecase
+
+import org.gradle.api.Project
+import org.jgrapht.graph.DirectedAcyclicGraph
+
+class BuildDagFromDependencyPairsImpl : BuildDagFromDependencyPairs {
+
+    override fun invoke(
+        dependencyPairs: List<Triple<Project, Project, String>>
+    ): DirectedAcyclicGraph<String, String> {
+        val dag = DirectedAcyclicGraph<String, String>(String::class.java)
+
+        dependencyPairs.forEach { (project, dependency, configuration) ->
+            dag.addVertex(project.name)
+            dag.addVertex(dependency.name)
+            dag.addEdge(project.name, dependency.name, configuration)
+        }
+
+        return dag
+    }
+}

--- a/cacheinvalidationindex/src/test/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/BuildDagFromDependencyPairsImplTest.kt
+++ b/cacheinvalidationindex/src/test/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/BuildDagFromDependencyPairsImplTest.kt
@@ -1,0 +1,44 @@
+package com.ivanalvarado.cacheinvalidationindex.domain.usecase
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.jgrapht.graph.DirectedAcyclicGraph
+import org.junit.Test
+
+
+class BuildDagFromDependencyPairsImplTest {
+
+    val buildDagFromDependencyPairs = BuildDagFromDependencyPairsImpl()
+
+    @Test
+    fun `invoke - given a list of dependency pairs, should return a directed acyclic graph`() {
+        // Given
+        val dependencyPairs = getDependencyPairs()
+        val expected = DirectedAcyclicGraph.createBuilder<String, String>(String::class.java)
+            .addEdge("root", "feature", "implementation")
+            .addEdge("feature", "featureImpl", "implementation")
+            .addEdge("featureImpl", "library", "api")
+            .addEdge("library", "testingLibrary", "testImplementation")
+            .build()
+
+        // When
+        val result = buildDagFromDependencyPairs(dependencyPairs)
+
+        // Then
+        assertThat(result).isEqualTo(expected)
+    }
+
+    private fun getDependencyPairs(): List<Triple<Project, Project, String>> {
+        return listOf(
+            Triple(buildProject("root"), buildProject("feature"), "implementation"),
+            Triple(buildProject("feature"), buildProject("featureImpl"), "implementation"),
+            Triple(buildProject("featureImpl"), buildProject("library"), "api"),
+            Triple(buildProject("library"), buildProject("testingLibrary"), "testImplementation")
+        )
+    }
+
+    private fun buildProject(name: String): Project {
+        return ProjectBuilder.builder().withName(name).build()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,13 @@
 [versions]
 jetbrainsKotlinJvm = "1.9.24"
+jgrapht = "1.5.1"
 junit = "4.13.2"
 truth = "1.4.4"
 
 [libraries]
+jgrapht-core = { group = "org.jgrapht", name = "jgrapht-core", version.ref = "jgrapht" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 
 [plugins]
 jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "jetbrainsKotlinJvm" }
-


### PR DESCRIPTION
### Summary
- Introduces a new use case that builds a Directed Acyclic Graph from dependency pairs.

### Example
#### Input 
```mermaid
graph TD
    root -->|implementation| feature
    feature -->|implementation| featureImpl
    featureImpl -->|api| library
    library -->|testImplementation| testingLibrary
```
#### Output
  ```
  ([root, feature, featureImpl, library, testingLibrary], 
   [implementation=(root,feature), implementation=(feature,featureImpl), api=(featureImpl,library), testImplementation=(library,testingLibrary)])
  ```

### Testing  
- [X] Unit tests verify that the DAG is correctly built from the defined dependency pairs.