### PR TITLE
Add a use case that builds Affected Subgraphs

### DIFF
--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/CacheInvalidationIndexPlugin.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/CacheInvalidationIndexPlugin.kt
@@ -1,5 +1,6 @@
 package com.ivanalvarado.cacheinvalidationindex
 
+import com.ivanalvarado.cacheinvalidationindex.domain.usecase.AffectedSubgraphsImpl
 import com.ivanalvarado.cacheinvalidationindex.domain.usecase.BuildDagFromDependencyPairsImpl
 import com.ivanalvarado.cacheinvalidationindex.domain.usecase.FindDependencyPairsImpl
 import org.gradle.api.Plugin
@@ -18,7 +19,8 @@ class CacheInvalidationIndexPlugin : Plugin<Project> {
             "cacheInvalidationIndex",
             CacheInvalidationIndexTask::class.java,
             FindDependencyPairsImpl(),
-            BuildDagFromDependencyPairsImpl()
+            BuildDagFromDependencyPairsImpl(),
+            AffectedSubgraphsImpl()
         )
         cacheInvalidationIndexTaskProvider.configure { task ->
             task.configurationToAnalyze.set(extension.configurationToAnalyze)

--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/CacheInvalidationIndexTask.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/CacheInvalidationIndexTask.kt
@@ -1,5 +1,6 @@
 package com.ivanalvarado.cacheinvalidationindex
 
+import com.ivanalvarado.cacheinvalidationindex.domain.usecase.AffectedSubgraphs
 import com.ivanalvarado.cacheinvalidationindex.domain.usecase.BuildDagFromDependencyPairs
 import com.ivanalvarado.cacheinvalidationindex.domain.usecase.FindDependencyPairs
 import org.gradle.api.DefaultTask
@@ -10,7 +11,8 @@ import javax.inject.Inject
 
 abstract class CacheInvalidationIndexTask @Inject constructor(
     private val findDependencyPairs: FindDependencyPairs,
-    private val buildDagFromDependencyPairs: BuildDagFromDependencyPairs
+    private val buildDagFromDependencyPairs: BuildDagFromDependencyPairs,
+    private val affectedSubgraphs: AffectedSubgraphs
 ) : DefaultTask() {
 
     @get:Input

--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/model/AffectedSubgraphDetails.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/model/AffectedSubgraphDetails.kt
@@ -1,0 +1,8 @@
+package com.ivanalvarado.cacheinvalidationindex.domain.model
+
+import org.jgrapht.graph.AbstractGraph
+
+data class AffectedSubgraphDetails(
+    val node: String,
+    val affectedDag: AbstractGraph<String, DependencyEdge>
+)

--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/model/DependencyEdge.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/model/DependencyEdge.kt
@@ -1,0 +1,9 @@
+package com.ivanalvarado.cacheinvalidationindex.domain.model
+
+import org.jgrapht.graph.DefaultEdge
+
+class DependencyEdge(val configuration: String) : DefaultEdge() {
+    override fun toString(): String {
+        return "($source : $target : $configuration)"
+    }
+}

--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/AffectedSubgraphs.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/AffectedSubgraphs.kt
@@ -1,0 +1,9 @@
+package com.ivanalvarado.cacheinvalidationindex.domain.usecase
+
+import com.ivanalvarado.cacheinvalidationindex.domain.model.AffectedSubgraphDetails
+import com.ivanalvarado.cacheinvalidationindex.domain.model.DependencyEdge
+import org.jgrapht.graph.DirectedAcyclicGraph
+
+interface AffectedSubgraphs {
+    operator fun invoke(graph: DirectedAcyclicGraph<String, DependencyEdge>): List<AffectedSubgraphDetails>
+}

--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/AffectedSubgraphsImpl.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/AffectedSubgraphsImpl.kt
@@ -1,0 +1,64 @@
+package com.ivanalvarado.cacheinvalidationindex.domain.usecase
+
+import com.ivanalvarado.cacheinvalidationindex.domain.model.AffectedSubgraphDetails
+import com.ivanalvarado.cacheinvalidationindex.domain.model.DependencyEdge
+import org.jgrapht.graph.DirectedAcyclicGraph
+
+class AffectedSubgraphsImpl : AffectedSubgraphs {
+    override fun invoke(
+        graph: DirectedAcyclicGraph<String, DependencyEdge>
+    ): List<AffectedSubgraphDetails> {
+        return graph.vertexSet().map { node ->
+            val subgraph = buildSubgraphForNode(graph, node)
+            AffectedSubgraphDetails(node, subgraph)
+        }
+    }
+
+    private fun buildSubgraphForNode(
+        graph: DirectedAcyclicGraph<String, DependencyEdge>,
+        node: String
+    ): DirectedAcyclicGraph<String, DependencyEdge> {
+        val nodesToInclude = mutableSetOf<String>()
+        val edgesToInclude = mutableSetOf<DependencyEdge>()
+
+        fun traverse(current: String) {
+            // Look at every incoming edge from a source node to 'current'
+            for (edge in graph.incomingEdgesOf(current)) {
+                val source = graph.getEdgeSource(edge)
+                when (edge.configuration) {
+                    "api" -> {
+                        // If we see an API dependency, include the source and keep going.
+                        if (nodesToInclude.add(source)) {
+                            edgesToInclude.add(edge)
+                            traverse(source)
+                        }
+                    }
+                    "implementation" -> {
+                        // For implementation, include the source but do not continue further.
+                        nodesToInclude.add(source)
+                        edgesToInclude.add(edge)
+                    }
+                    // Ignore other dependency types (e.g., testImplementation)
+                }
+            }
+        }
+
+        nodesToInclude.add(node)
+        traverse(node)
+
+        val builder = DirectedAcyclicGraph.createBuilder<String, DependencyEdge>(
+            DependencyEdge::class.java
+        )
+        nodesToInclude.forEach { builder.addVertex(it) }
+        edgesToInclude.forEach { edge ->
+            val source = graph.getEdgeSource(edge)
+            val target = graph.getEdgeTarget(edge)
+            // Only add the edge if both vertices are in the subgraph.
+            if (nodesToInclude.contains(source) && nodesToInclude.contains(target)) {
+                builder.addEdge(source, target, edge)
+            }
+        }
+        return builder.build()
+    }
+}
+

--- a/cacheinvalidationindex/src/test/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/AffectedSubgraphsImplTest.kt
+++ b/cacheinvalidationindex/src/test/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/AffectedSubgraphsImplTest.kt
@@ -1,0 +1,96 @@
+package com.ivanalvarado.cacheinvalidationindex.domain.usecase
+
+import com.google.common.truth.Truth.assertThat
+import com.ivanalvarado.cacheinvalidationindex.domain.model.AffectedSubgraphDetails
+import com.ivanalvarado.cacheinvalidationindex.domain.model.DependencyEdge
+import org.jgrapht.graph.DirectedAcyclicGraph
+import org.junit.Test
+
+class AffectedSubgraphsImplTest {
+
+    val affectedSubgraphs = AffectedSubgraphsImpl()
+
+    @Test
+    fun `invoke - given a directed acyclic graph, should return a list of sets of affected nodes`() {
+        // Given
+        val dag = getDag()
+        val expected = listOf(
+            AffectedSubgraphDetails("root", DirectedAcyclicGraph.createBuilder<String, DependencyEdge>(DependencyEdge::class.java)
+                .addVertex("root")
+                .build()
+            ),
+            AffectedSubgraphDetails("feature", DirectedAcyclicGraph.createBuilder<String, DependencyEdge>(DependencyEdge::class.java)
+                .addEdge("root", "feature", DependencyEdge("implementation"))
+                .build()
+            ),
+            AffectedSubgraphDetails("featureImpl", DirectedAcyclicGraph.createBuilder<String, DependencyEdge>(DependencyEdge::class.java)
+                .addEdge("feature", "featureImpl", DependencyEdge("api"))
+                .addEdge("root", "feature", DependencyEdge("implementation"))
+                .build()
+            ),
+            AffectedSubgraphDetails("core", DirectedAcyclicGraph.createBuilder<String, DependencyEdge>(DependencyEdge::class.java)
+                .addEdge("featureImpl", "core", DependencyEdge("api"))
+                .addEdge("feature", "featureImpl", DependencyEdge("api"))
+                .addEdge("root", "feature", DependencyEdge("implementation"))
+                .build()
+            ),
+            AffectedSubgraphDetails("library", DirectedAcyclicGraph.createBuilder<String, DependencyEdge>(DependencyEdge::class.java)
+                .addEdge("featureImpl", "library", DependencyEdge("api"))
+                .addEdge("feature", "featureImpl", DependencyEdge("api"))
+                .addEdge("root", "feature", DependencyEdge("implementation"))
+                .build()
+            ),
+            AffectedSubgraphDetails("testingLibrary", DirectedAcyclicGraph.createBuilder<String, DependencyEdge>(DependencyEdge::class.java)
+                .addVertex("testingLibrary")
+                .build()
+            )
+        )
+
+        // When
+        val result = affectedSubgraphs(dag)
+
+        // Then
+        assertThat(result[0].node).isEqualTo(expected[0].node)
+        assertThat(result[1].node).isEqualTo(expected[1].node)
+        assertThat(result[2].node).isEqualTo(expected[2].node)
+        assertThat(result[3].node).isEqualTo(expected[3].node)
+        assertThat(result[4].node).isEqualTo(expected[4].node)
+        assertThat(result[5].node).isEqualTo(expected[5].node)
+        assertThat(result[0].affectedDag.vertexSet()).isEqualTo(expected[0].affectedDag.vertexSet())
+        assertThat(result[1].affectedDag.vertexSet()).isEqualTo(expected[1].affectedDag.vertexSet())
+        assertThat(result[2].affectedDag.vertexSet()).isEqualTo(expected[2].affectedDag.vertexSet())
+        assertThat(result[3].affectedDag.vertexSet()).isEqualTo(expected[3].affectedDag.vertexSet())
+        assertThat(result[4].affectedDag.vertexSet()).isEqualTo(expected[4].affectedDag.vertexSet())
+        assertThat(result[5].affectedDag.vertexSet()).isEqualTo(expected[5].affectedDag.vertexSet())
+        assertThat(result[0].affectedDag.edgeSet()).isEqualTo(expected[0].affectedDag.edgeSet())
+        assertThat(result[1].affectedDag.edgeSet().toString()).isEqualTo(expected[1].affectedDag.edgeSet().toString())
+        assertThat(result[2].affectedDag.edgeSet().toString()).isEqualTo(expected[2].affectedDag.edgeSet().toString())
+        assertThat(result[3].affectedDag.edgeSet().toString()).isEqualTo(expected[3].affectedDag.edgeSet().toString())
+        assertThat(result[4].affectedDag.edgeSet().toString()).isEqualTo(expected[4].affectedDag.edgeSet().toString())
+        assertThat(result[5].affectedDag.edgeSet().toString()).isEqualTo(expected[5].affectedDag.edgeSet().toString())
+    }
+
+    /**
+     * Builds a simple multi-project structure:
+     *  ```mermaid
+     *  graphTD
+     *  root -> feature (implementation)
+     *  root -> featureImpl (implementation)
+     *  feature -> featureImpl (api)
+     *  featureImpl -> library (api)
+     *  featureImpl -> testingLibrary (testImplementation)
+     *  featureImpl -> core (api)
+     *  library -> testingLibrary (testImplementation)
+     *  ```
+     */
+    private fun getDag(): DirectedAcyclicGraph<String, DependencyEdge> {
+        return DirectedAcyclicGraph.createBuilder<String, DependencyEdge>(DependencyEdge::class.java)
+            .addEdge("root", "feature", DependencyEdge("implementation"))
+            .addEdge("feature", "featureImpl", DependencyEdge("api"))
+            .addEdge("featureImpl", "core", DependencyEdge("api"))
+            .addEdge("featureImpl", "library", DependencyEdge("api"))
+            .addEdge("featureImpl", "testingLibrary", DependencyEdge("testImplementation"))
+            .addEdge("library", "testingLibrary", DependencyEdge("testImplementation"))
+            .build()
+    }
+}


### PR DESCRIPTION
### Summary
- Adds a use case that returns subgraphs for each subproject and its ancestors that are configured with `api` and `implementation`
- **Motivation**: The goal here is to highlight all subprojects that would be triggered to recompile if breaking changes to the public API are introduced to the module in question. This is helpful to better understand the implications of these breaking changes and highlight the blast radius.

For example, if we had the following project graph:
```mermaid
graph TD
     root -->|implementation| feature 
     feature -->|api| featureImpl 
     featureImpl -->|api| library
     featureImpl -->|testImplementation| testingLibrary 
     featureImpl -->|api| core
     library -->|testImplementation| testingLibrary
```

This use case will return the following subgraphs:

#### root
```mermaid
graph TD
    root
```

#### feature
``` mermaid
graph TD
     root -->|implementation| feature 
```

#### featureImpl
```mermaid
graph TD
     root -->|implementation| feature 
     feature -->|api| featureImpl 
```

#### library
```mermaid
graph TD
     root -->|implementation| feature 
     feature -->|api| featureImpl 
     featureImpl -->|api| library
```

#### core
```mermaid
graph TD
     root -->|implementation| feature 
     feature -->|api| featureImpl 
     featureImpl -->|api| core
```

#### testingLibrary
```mermaid
graph TD
    testingLibrary
```