### PR TITLE
Use `DependencyEdge` Type for edges in the DAG

### DIFF
--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/CacheInvalidationIndexTask.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/CacheInvalidationIndexTask.kt
@@ -26,5 +26,7 @@ abstract class CacheInvalidationIndexTask @Inject constructor(
         println("Dependency Pairs: $sampleList")
         val dag = buildDagFromDependencyPairs(sampleList)
         println("DAG: $dag")
+        val affectedSubgraphs = affectedSubgraphs(dag)
+        println("Affected Subgraphs: $affectedSubgraphs")
     }
 }

--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/BuildDagFromDependencyPairs.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/BuildDagFromDependencyPairs.kt
@@ -1,8 +1,9 @@
 package com.ivanalvarado.cacheinvalidationindex.domain.usecase
 
+import com.ivanalvarado.cacheinvalidationindex.domain.model.DependencyEdge
 import org.gradle.api.Project
 import org.jgrapht.graph.DirectedAcyclicGraph
 
 interface BuildDagFromDependencyPairs {
-    operator fun invoke(dependencyPairs: List<Triple<Project, Project, String>>): DirectedAcyclicGraph<String, String>
+    operator fun invoke(dependencyPairs: List<Triple<Project, Project, String>>): DirectedAcyclicGraph<String, DependencyEdge>
 }

--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/BuildDagFromDependencyPairsImpl.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/usecase/BuildDagFromDependencyPairsImpl.kt
@@ -1,5 +1,6 @@
 package com.ivanalvarado.cacheinvalidationindex.domain.usecase
 
+import com.ivanalvarado.cacheinvalidationindex.domain.model.DependencyEdge
 import org.gradle.api.Project
 import org.jgrapht.graph.DirectedAcyclicGraph
 
@@ -7,13 +8,13 @@ class BuildDagFromDependencyPairsImpl : BuildDagFromDependencyPairs {
 
     override fun invoke(
         dependencyPairs: List<Triple<Project, Project, String>>
-    ): DirectedAcyclicGraph<String, String> {
-        val dag = DirectedAcyclicGraph<String, String>(String::class.java)
+    ): DirectedAcyclicGraph<String, DependencyEdge> {
+        val dag = DirectedAcyclicGraph<String, DependencyEdge>(DependencyEdge::class.java)
 
         dependencyPairs.forEach { (project, dependency, configuration) ->
             dag.addVertex(project.name)
             dag.addVertex(dependency.name)
-            dag.addEdge(project.name, dependency.name, configuration)
+            dag.addEdge(project.name, dependency.name, DependencyEdge(configuration))
         }
 
         return dag


### PR DESCRIPTION
### Summary
- **What**: Use the [`DependencyEdge`](https://github.com/ivanalvarado/cache-invalidation-index-plugin/blob/main/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/domain/model/DependencyEdge.kt) Type for the edges in the DirectedAcyclicGraph object.
- **Motivation**: Every edge in the DAG has to be _unique_. If we simply used the `configuration` as a String, i.e. `implementation`, `api`, `testImplementation`, `debugImplementation` etc., only the `set().size` of those nodes will be added to the graph. Providing the source node, target node, and the configuration will _guarantee_ unique values for each edge in the graph.