### PR TITLE
Output the graph to `dot` file for `png` rendering support

### DIFF
--- a/cacheinvalidationindex/build.gradle.kts
+++ b/cacheinvalidationindex/build.gradle.kts
@@ -19,6 +19,7 @@ gradlePlugin {
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(libs.jgrapht.core)
+    implementation(libs.jgrapht.io)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)

--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/CacheInvalidationIndexPlugin.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/CacheInvalidationIndexPlugin.kt
@@ -3,6 +3,7 @@ package com.ivanalvarado.cacheinvalidationindex
 import com.ivanalvarado.cacheinvalidationindex.domain.usecase.AffectedSubgraphsImpl
 import com.ivanalvarado.cacheinvalidationindex.domain.usecase.BuildDagFromDependencyPairsImpl
 import com.ivanalvarado.cacheinvalidationindex.domain.usecase.FindDependencyPairsImpl
+import com.ivanalvarado.cacheinvalidationindex.writer.GraphVizWriter
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.internal.configuration.problems.taskPathFrom
@@ -20,7 +21,8 @@ class CacheInvalidationIndexPlugin : Plugin<Project> {
             CacheInvalidationIndexTask::class.java,
             FindDependencyPairsImpl(),
             BuildDagFromDependencyPairsImpl(),
-            AffectedSubgraphsImpl()
+            AffectedSubgraphsImpl(),
+            GraphVizWriter()
         )
         cacheInvalidationIndexTaskProvider.configure { task ->
             task.configurationToAnalyze.set(extension.configurationToAnalyze)

--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/writer/GraphVizWriter.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/writer/GraphVizWriter.kt
@@ -1,0 +1,37 @@
+package com.ivanalvarado.cacheinvalidationindex.writer
+
+import com.ivanalvarado.cacheinvalidationindex.domain.model.DependencyEdge
+import org.jgrapht.graph.AbstractGraph
+import org.jgrapht.nio.DefaultAttribute
+import org.jgrapht.nio.dot.DOTExporter
+import java.io.File
+
+class GraphVizWriter {
+
+    fun writeGraph(graph: AbstractGraph<String, DependencyEdge>, file: File) {
+        val exporter = DOTExporter<String, DependencyEdge> { vertex ->
+            vertex.sanitize()
+        }
+
+        exporter.setVertexAttributeProvider { vertex ->
+            buildMap {
+                put("label", DefaultAttribute.createAttribute(vertex))
+            }
+        }
+
+        exporter.setEdgeAttributeProvider { edge ->
+            buildMap {
+                put("label", DefaultAttribute.createAttribute(edge.configuration))
+            }
+        }
+
+        file.delete()
+        exporter.exportGraph(graph, file)
+    }
+
+    private fun String.sanitize(): String {
+        return this.replace("-", "_")
+            .replace(".", "_")
+            .replace(":", "_")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ truth = "1.4.4"
 
 [libraries]
 jgrapht-core = { group = "org.jgrapht", name = "jgrapht-core", version.ref = "jgrapht" }
+jgrapht-io = { group = "org.jgrapht", name = "jgrapht-io", version.ref = "jgrapht" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 


### PR DESCRIPTION
### Summary
- Output the generated graph to `dot` file format in project `build` directory

#### Sample
`sample/sample-jvm-module/build/graph.dot`
```dot
strict digraph G {
  _sample_jvm_module [ label=":sample-jvm-module" ];
  _sample_android_module [ label=":sample-android-module" ];
  _sample_android_module -> _sample_jvm_module [ label="implementation" ];
}
```
Executing the following command:
```
dot -Tpng sample-jvm-module/build/graph.dot -o sample-jvm-module/build/graph.png
```
Renders
`sample/sample-jvm-module/build/graph.png`
<img width="311" alt="image" src="https://github.com/user-attachments/assets/518a5f00-a01f-4e46-bc61-568bff181324" />
