### PR TITLE
Output the dependency graph in png format with graphviz-java

### DIFF
--- a/cacheinvalidationindex/build.gradle.kts
+++ b/cacheinvalidationindex/build.gradle.kts
@@ -18,6 +18,7 @@ gradlePlugin {
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
+    implementation(libs.graphviz.java)
     implementation(libs.jgrapht.core)
     implementation(libs.jgrapht.io)
 

--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/CacheInvalidationIndexTask.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/CacheInvalidationIndexTask.kt
@@ -29,7 +29,7 @@ abstract class CacheInvalidationIndexTask @Inject constructor(
         val affectedSubgraphs = affectedSubgraphs(dag)
         graphVizWriter.writeGraph(
             graph = affectedSubgraphs.find { it.node == project.path }!!.affectedDag,
-            file = project.file("build/graph.dot")
+            file = project.file("build/cacheinvalidationindex/dependency_graph.png")
         )
     }
 }

--- a/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/writer/GraphVizWriter.kt
+++ b/cacheinvalidationindex/src/main/java/com/ivanalvarado/cacheinvalidationindex/writer/GraphVizWriter.kt
@@ -1,10 +1,13 @@
 package com.ivanalvarado.cacheinvalidationindex.writer
 
 import com.ivanalvarado.cacheinvalidationindex.domain.model.DependencyEdge
+import guru.nidi.graphviz.engine.Format
+import guru.nidi.graphviz.engine.Graphviz
 import org.jgrapht.graph.AbstractGraph
 import org.jgrapht.nio.DefaultAttribute
 import org.jgrapht.nio.dot.DOTExporter
 import java.io.File
+import java.io.StringWriter
 
 class GraphVizWriter {
 
@@ -25,8 +28,14 @@ class GraphVizWriter {
             }
         }
 
+        val writer = StringWriter()
+        exporter.exportGraph(graph, writer)
+        val dotString = writer.toString()
+
         file.delete()
-        exporter.exportGraph(graph, file)
+        Graphviz.fromString(dotString)
+            .render(Format.PNG)
+            .toFile(file)
     }
 
     private fun String.sanitize(): String {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,12 @@
 [versions]
+graphviz-java = "0.18.1"
 jetbrainsKotlinJvm = "1.9.24"
 jgrapht = "1.5.1"
 junit = "4.13.2"
 truth = "1.4.4"
 
 [libraries]
+graphviz-java = { group = "guru.nidi", name = "graphviz-java", version.ref = "graphviz-java" }
 jgrapht-core = { group = "org.jgrapht", name = "jgrapht-core", version.ref = "jgrapht" }
 jgrapht-io = { group = "org.jgrapht", name = "jgrapht-io", version.ref = "jgrapht" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
### Summary 
- Output the dependency graph result in `.png` format rather than having to install [Graphviz](https://graphviz.org/) and continuously run `dot` commands to generate the `.png` files.
- Filepath: `<project>/build/cacheinvalidationindex/dependency_graph.png`

<img width="1476" alt="image" src="https://github.com/user-attachments/assets/58afb5e6-56b6-41b2-8acc-ae6b0b150839" />
 